### PR TITLE
Add tk gem runtime dependency

### DIFF
--- a/lib/trtl.rb
+++ b/lib/trtl.rb
@@ -1,7 +1,7 @@
 require 'tk'
 
 class Trtl
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 
   CANVAS_WIDTH = 800
   CANVAS_HEIGHT = 600

--- a/trtl.gemspec
+++ b/trtl.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_runtime_dependency 'tk', '~> 0.1'
 end


### PR DESCRIPTION
The `require trtl` fails if the tk gem is not installed.

I notice that the tk gem was only a couple of weeks ago so I don't know how it would have worked before.